### PR TITLE
fix: return raw response

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -38,8 +38,18 @@ export class APIService {
 			throw new SquareCloudAPIError("SERVER_UNAVAILABLE", "Try again later");
 		}
 
-		const data = await response.json().catch(() => {
-			throw new SquareCloudAPIError("CANNOT_PARSE_RESPONSE", "Try again later");
+		const data = await response.json().catch(async (parseError) => {
+			const responseText = await response
+				.clone()
+				.text()
+				.catch(() => "Failed to read raw response body.");
+			throw new SquareCloudAPIError(
+				"CANNOT_PARSE_RESPONSE",
+				`Raw API response: ${responseText}`,
+				{
+					cause: parseError,
+				},
+			);
 		});
 
 		if (!data || data.status === "error" || !response.ok) {


### PR DESCRIPTION
Ensure the API returns the raw response when the SDK is unable to parse it, allowing for easier debugging of the issue encountered.